### PR TITLE
Revert "Rename module to github.com/fastleansmart/grafana-sdk"

### DIFF
--- a/board_test.go
+++ b/board_test.go
@@ -22,7 +22,7 @@ package sdk_test
 import (
 	"testing"
 
-	sdk "github.com/fastleansmart/grafana-sdk"
+	"github.com/K-Phoen/sdk"
 )
 
 func TestAddTags(t *testing.T) {

--- a/custom-types_test.go
+++ b/custom-types_test.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdk "github.com/fastleansmart/grafana-sdk"
+	"github.com/K-Phoen/sdk"
 )
 
 func TestIntString_Unmarshal(t *testing.T) {

--- a/dashboard-unmarshal_test.go
+++ b/dashboard-unmarshal_test.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	sdk "github.com/fastleansmart/grafana-sdk"
+	"github.com/K-Phoen/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fastleansmart/grafana-sdk
+module github.com/K-Phoen/sdk
 
 go 1.19
 

--- a/panel_test.go
+++ b/panel_test.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	sdk "github.com/fastleansmart/grafana-sdk"
+	"github.com/K-Phoen/sdk"
 )
 
 func TestStackVal_UnmarshalJSON_GotTrue(t *testing.T) {


### PR DESCRIPTION
This reverts commit 1758e1f9b1979fdf778dbea50476549562d90f5c.