### PR TITLE
extend annotation to include more fields

### DIFF
--- a/board.go
+++ b/board.go
@@ -128,7 +128,7 @@ type (
 		Tags        []string           `json:"tags"`
 		TagKeys     string             `json:"tagKeys"`
 		Type        string             `json:"type"`
-		Filter      []AnnotationFilter `json:"filter"`
+		Filter      AnnotationFilter `json:"filter"`
 		Hide        bool               `json:"hide"`
 	}
 

--- a/board.go
+++ b/board.go
@@ -111,24 +111,33 @@ type (
 		Value interface{}        `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {
-		Name        string         `json:"name"`
-		Datasource  *DatasourceRef `json:"datasource"`
-		ShowLine    bool           `json:"showLine"`
-		IconColor   string         `json:"iconColor"`
-		LineColor   string         `json:"lineColor"`
-		IconSize    uint           `json:"iconSize"`
-		Enable      bool           `json:"enable"`
-		Query       string         `json:"query"`
-		Expr        string         `json:"expr"`
-		Step        string         `json:"step"`
-		TextField   string         `json:"textField"`
-		TextFormat  string         `json:"textFormat"`
-		TitleFormat string         `json:"titleFormat"`
-		TagsField   string         `json:"tagsField"`
-		Tags        []string       `json:"tags"`
-		TagKeys     string         `json:"tagKeys"`
-		Type        string         `json:"type"`
+		Name        string             `json:"name"`
+		Datasource  *DatasourceRef     `json:"datasource"`
+		ShowLine    bool               `json:"showLine"`
+		IconColor   string             `json:"iconColor"`
+		LineColor   string             `json:"lineColor"`
+		IconSize    uint               `json:"iconSize"`
+		Enable      bool               `json:"enable"`
+		Query       string             `json:"query"`
+		Expr        string             `json:"expr"`
+		Step        string             `json:"step"`
+		TextField   string             `json:"textField"`
+		TextFormat  string             `json:"textFormat"`
+		TitleFormat string             `json:"titleFormat"`
+		TagsField   string             `json:"tagsField"`
+		Tags        []string           `json:"tags"`
+		TagKeys     string             `json:"tagKeys"`
+		Type        string             `json:"type"`
+		Filter      []AnnotationFilter `json:"filter"`
+		Hide        bool               `json:"hide"`
 	}
+
+	// For Annotation
+	AnnotationFilter struct {
+		Exclude bool   `json:"exclude"`
+		Ids     []uint `json:"ids"`
+	}
+
 	// Link represents link to another dashboard or external weblink
 	Link struct {
 		Title       string   `json:"title"`


### PR DESCRIPTION
* adds some fields to annotations, so it works with the current version of Grafana
* adds the following new fields:
```go
		Filter      []AnnotationFilter `json:"filter"`
		Hide        bool               `json:"hide"`
```